### PR TITLE
Add snapshot history module and wire into app for final report foundation

### DIFF
--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -26,6 +26,8 @@ import { toggleIssuesPanel as doToggleIssuesPanel } from "./actions/issues.js";
 import { exportPhoneSnapshot } from "./export/phone.js";
 import { exportEmailSnapshot } from "./export/email.js";
 import { exportGanttChart } from "./export/gantt.js";
+import { exportFinalReport } from "./export/finalReport.js";
+import { startAutoSnapshot, recordSnapshot } from "./history.js";
 
 // ── Helpers ────────────────────────────────────────────────
 
@@ -148,6 +150,7 @@ function updatePaletteButton() {
 function setHealth(status) {
     doSetHealth(status);
     renderHealthIndicator();
+    recordSnapshot(); // capture health transition immediately
 }
 
 // ── Team filter ────────────────────────────────────────────
@@ -269,6 +272,14 @@ function showEmailExportOptions() {
 }
 
 function exportGantt() { exportGanttChart(showToast); }
+
+async function exportReport() {
+    try {
+        await exportFinalReport(showToast);
+    } catch (e) {
+        showToast("Failed to generate report");
+    }
+}
 
 function exportJSON() {
     exportRunbookJson();
@@ -461,6 +472,7 @@ function bindEvents() {
     exportMenu.querySelector('[data-action="gantt-export"]').addEventListener("click", () => { exportMenu.classList.remove("open"); exportGantt(); });
     exportMenu.querySelector('[data-action="summary"]').addEventListener("click", () => { exportMenu.classList.remove("open"); generateSummary(); });
     exportMenu.querySelector('[data-action="export-json"]').addEventListener("click", () => { exportMenu.classList.remove("open"); exportJSON(); });
+    exportMenu.querySelector('[data-action="final-report"]').addEventListener("click", () => { exportMenu.classList.remove("open"); exportReport(); });
 
     document.querySelector('[data-action="expand-all"]').addEventListener("click", expandAll);
     document.querySelector('[data-action="collapse-all"]').addEventListener("click", collapseAll);
@@ -498,3 +510,4 @@ updateClock();
 setInterval(updateClock, 1000);
 bindEvents();
 loadConfig().then(() => { detectAssets(); loadRunbook(); });
+startAutoSnapshot(15 * 60 * 1000);

--- a/dashboard/history.js
+++ b/dashboard/history.js
@@ -1,0 +1,93 @@
+// ============================================================
+// history.js — Snapshot history for burndown chart / final report
+// ============================================================
+// Records timestamped completion snapshots to localStorage so
+// the Final Report can render a burndown curve and health timeline.
+// ============================================================
+
+import { state } from "./state.js";
+import { getGlobalStats } from "./selectors.js";
+
+const STORAGE_KEY = "runbook_snapshots";
+const MAX_SNAPSHOTS = 200;
+
+let _timerId = null;
+
+// ── Internal ──────────────────────────────────────────────
+
+function _load() {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        return raw ? JSON.parse(raw) : [];
+    } catch (_) {
+        return [];
+    }
+}
+
+function _save(snapshots) {
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshots));
+    } catch (_) { /* quota exceeded — skip silently */ }
+}
+
+// ── Public API ────────────────────────────────────────────
+
+/**
+ * Record the current completion state as a snapshot.
+ * Deduplicates back-to-back identical pct values (noise reduction).
+ */
+export function recordSnapshot() {
+    const { total, done, inProg, notStarted, blocking } = getGlobalStats();
+    const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+    const health = state.healthStatus || "Green";
+
+    const snapshots = _load();
+
+    // Skip duplicate: same pct and same health as the previous entry
+    const last = snapshots[snapshots.length - 1];
+    if (last && last.pct === pct && last.health === health) return;
+
+    snapshots.push({ ts: new Date().toISOString(), pct, done, total, inProg, notStarted, blocking, health });
+
+    // Cap to MAX_SNAPSHOTS (drop oldest)
+    if (snapshots.length > MAX_SNAPSHOTS) snapshots.splice(0, snapshots.length - MAX_SNAPSHOTS);
+
+    _save(snapshots);
+}
+
+/**
+ * Return the full array of recorded snapshots (oldest first).
+ * @returns {Array<{ts:string, pct:number, done:number, total:number, inProg:number, notStarted:number, blocking:number, health:string}>}
+ */
+export function getSnapshots() {
+    return _load();
+}
+
+/**
+ * Clear all recorded snapshots from localStorage.
+ */
+export function clearSnapshots() {
+    localStorage.removeItem(STORAGE_KEY);
+}
+
+/**
+ * Start an auto-snapshot timer.
+ * Records immediately, then repeats every `intervalMs` milliseconds.
+ * Calling this again replaces any existing timer.
+ * @param {number} [intervalMs=900000] — default 15 minutes
+ */
+export function startAutoSnapshot(intervalMs = 15 * 60 * 1000) {
+    if (_timerId !== null) clearInterval(_timerId);
+    recordSnapshot(); // record immediately on start
+    _timerId = setInterval(recordSnapshot, intervalMs);
+}
+
+/**
+ * Stop the auto-snapshot timer (if running).
+ */
+export function stopAutoSnapshot() {
+    if (_timerId !== null) {
+        clearInterval(_timerId);
+        _timerId = null;
+    }
+}

--- a/dashboard/persistence.js
+++ b/dashboard/persistence.js
@@ -127,7 +127,7 @@ export function exportRunbookJson() {
 }
 
 /**
- * Reset all tasks to "Not Started", clear issues and health.
+ * Reset all tasks to "Not Started", clear issues, health, and snapshot history.
  * Confirmation is handled by the caller (app.js showConfirm modal).
  * Returns true when reset was performed.
  */
@@ -140,5 +140,6 @@ export function resetRunbook() {
     state.healthStatus = "Green";
     state.runbookData[RESERVED_KEYS.health] = "Green";
     localStorage.removeItem("runbook_progress");
+    localStorage.removeItem("runbook_snapshots");
     return true;
 }


### PR DESCRIPTION
- dashboard/history.js: new module that records timestamped completion
  snapshots (pct, done, total, health) to localStorage every 15 min,
  with deduplication and a 200-entry cap
- dashboard/app.js: import history module, start auto-snapshot on boot,
  record snapshot on health change, wire future Final Report export button
- dashboard/persistence.js: clear runbook_snapshots on full reset so
  history does not bleed across unrelated go-live events

https://claude.ai/code/session_01Y3FHcJmrgq1RySGy3CarBA