### PR TITLE
Fix logo display failures and add auto-resize for oversized logos

### DIFF
--- a/Tasks/Bugs/logo-display-analysis.md
+++ b/Tasks/Bugs/logo-display-analysis.md
@@ -1,0 +1,240 @@
+# Logo Retrieval & Display — Bug Analysis & Fix Plan
+
+## Overview
+
+The app displays a client logo in two places:
+- **Home page** (`welcome.html`) — on each recent-client card
+- **Dashboard header** (`runbookDashboard.html`) — in the `#clientLogo` `<img>` element
+
+These two pages use **completely separate mechanisms** to source the logo. Several silent failure modes cause the logo to disappear without any user feedback.
+
+---
+
+## Full Algorithm
+
+### HOME PAGE (`welcome.html`)
+
+#### Path A — Opening a NEW folder (`openNewFolder`)
+
+```
+User clicks "Open Folder"
+  → electronAPI.openFolder()                    OS file picker → folderPath
+  → electronAPI.readConfig(folderPath)          reads config.json
+  → if cfg.logoFile:
+      electronAPI.readFileAsDataUrl(folderPath, cfg.logoFile)
+        → IPC: folder:readFileAsDataUrl (electron-main.js ~244)
+            reads file from disk
+            enforces size cap → null if exceeded (before fix)
+            converts to base64 data URL: "data:image/png;base64,..."
+  → electronAPI.addRecentClient({ ...fields, logoDataUrl })
+      → IPC: store:addRecent (electron-main.js ~261)
+          if logoDataUrl.length > 350_000 → strips to '' silently
+          saves to ~/.mxrunbook/recent-clients.json
+  → electronAPI.openDashboard(folderPath)
+```
+
+#### Path B — Re-opening a RECENT folder (`openRecentFolder`)
+
+```
+User clicks a recent card
+  → electronAPI.readConfig(entry.path)          verify folder accessible
+  → electronAPI.addRecentClient({ ...entry, lastOpened: now })
+      ⚠️ spreads old entry verbatim — NEVER re-reads the logo file
+  → electronAPI.openDashboard(entry.path)
+```
+
+#### Rendering recent cards (`renderRecentCards`)
+
+```
+For each stored recent entry r:
+  if r.logoDataUrl is truthy:
+    → <img src="{r.logoDataUrl}" onerror="show letter fallback">
+  else:
+    → <span> with first letter of clientName
+```
+
+---
+
+### DASHBOARD PAGE (`runbookDashboard.html` → `dashboard/app.js`)
+
+#### Bootstrap sequence
+
+```
+loadConfig() → detectAssets() → loadRunbook()
+```
+
+#### `loadConfig()` (~line 81)
+
+```
+if ?clientKey in URL → fetch /client-config
+else                 → fetch config.json
+merge into state.projectConfig
+applyConfig()  ← sets title/subtitle/accent colour; does NOT touch the logo
+```
+
+#### `detectAssets()` — full logo loading logic (~line 339)
+
+```
+Step 1 — Determine URL prefix:
+  isClientMode = URL has '?clientKey'
+  clientPrefix = isClientMode ? '/client-asset/' : 'assets/'
+
+Step 2 — Load logo if configured:
+  if state.projectConfig.logoFile:
+    loadLogo(clientPrefix + logoFile)
+      img.onload → set #clientLogo.src, remove .hidden class, update favicon
+      img.onerror → tryAutoDetect()   ⚠️ called even in client mode (wrong)
+
+Step 3 — Load background:
+  if state.projectConfig.backgroundFile:
+    loadBg(clientPrefix + backgroundFile)
+  if no backgroundFile AND not clientMode:
+    loadBg('assets/Murex_background6.jpg')
+
+Step 4 — Delayed auto-detect (150 ms timeout):
+  if NOT clientMode AND (logo or bg not yet loaded):
+    tryAutoDetect()   ← auto-detect fully disabled in client mode
+```
+
+#### `tryAutoDetect()` (~line 389)
+
+```
+Guard: runs only once (autoDetectAttempted flag)
+fetch('assets/')                     ⚠️ hardcoded path — wrong in client mode
+  parse HTML for href matching *logo*.(png|jpg|jpeg|svg|webp)
+  on success: loadLogo('assets/' + logoName)
+  on fetch error (no directory listing):
+    parallel Image() guesses: logo.*, client-logo.*, clientlogo.*
+```
+
+---
+
+## Bugs Found
+
+| # | Bug | File & Location | Impact |
+|---|-----|-----------------|--------|
+| B1 | Recent re-open never refreshes `logoDataUrl` | `welcome.html openRecentFolder` | Logo stays missing forever if null on first open |
+| B2 | Silent 350 K char cap strips stored logos without warning | `electron-main.js store:addRecent ~264` | Large logos vanish with no feedback |
+| B3 | 256 KB hard cap returns `null` instead of resizing | `electron-main.js readFileAsDataUrl ~253` | Any logo > 256 KB is silently dropped |
+| B4 | `tryAutoDetect()` hardcodes `'assets/'` path | `dashboard/app.js ~393` | In client mode fetches wrong URL, finds nothing |
+| B5 | `img.onerror` calls `tryAutoDetect()` even in client mode | `dashboard/app.js ~360` | Silent no-op in client mode when logoFile is wrong |
+| B6 | Config fetch failure is silently swallowed | `dashboard/app.js ~86-88` | `state.projectConfig.logoFile` stays undefined; no logo loads |
+
+---
+
+## Fix Plan
+
+### Fix B3 + B2 — Auto-resize logo in the IPC handler (`electron-main.js`)
+
+**Status: ✅ Implemented**
+
+`sharp` (already installed, moved to `dependencies`) is used inside the `folder:readFileAsDataUrl` handler. The handler is now `async`. Files already under 250 KB are returned unchanged. Larger files go through a 3-pass resize pipeline:
+
+| Pass | Dimensions | Format | Quality |
+|------|-----------|--------|---------|
+| 1 | 512 × 512 max | PNG (lossless) | compressionLevel 9 |
+| 2 | 256 × 256 max | JPEG | 85% |
+| 3 | 128 × 128 max | JPEG | 60% |
+
+**Why 250 KB?** 250 KB binary → ~333 K base64 chars → safely under the 350 K `store:addRecent` cap.
+
+```javascript
+// electron-main.js ~245
+ipcMain.handle('folder:readFileAsDataUrl', async (_, folderPath, filename) => {
+    // ...security checks...
+    const data = fs.readFileSync(filePath);
+    const TARGET = 250 * 1024;
+
+    if (data.length <= TARGET) {
+        return `data:${mime};base64,${data.toString('base64')}`;
+    }
+
+    const sharp = require('sharp');
+    // Pass 1: PNG, 512×512 max
+    let out = await sharp(data).resize(512,512,{fit:'inside',withoutEnlargement:true}).png({compressionLevel:9}).toBuffer();
+    if (out.length <= TARGET) return `data:image/png;base64,${out.toString('base64')}`;
+    // Pass 2: JPEG 85%, 256×256 max
+    out = await sharp(data).resize(256,256,{fit:'inside',withoutEnlargement:true}).jpeg({quality:85}).toBuffer();
+    if (out.length <= TARGET) return `data:image/jpeg;base64,${out.toString('base64')}`;
+    // Pass 3: JPEG 60%, 128×128 max (last resort)
+    out = await sharp(data).resize(128,128,{fit:'inside',withoutEnlargement:true}).jpeg({quality:60}).toBuffer();
+    return `data:image/jpeg;base64,${out.toString('base64')}`;
+});
+```
+
+---
+
+### Fix B1 — Refresh `logoDataUrl` on every recent folder open (`welcome.html`)
+
+**Status: ✅ Implemented**
+
+`openRecentFolder` now re-reads the logo file after verifying the config, using the same `readFileAsDataUrl` call as `openNewFolder`. The fresh data URL is passed to `addRecentClient`, replacing the stale stored value.
+
+```javascript
+// welcome.html openRecentFolder
+let logoDataUrl = entry.logoDataUrl || '';
+if (cfg.logoFile) {
+    logoDataUrl = await window.electronAPI.readFileAsDataUrl(entry.path, cfg.logoFile) || logoDataUrl;
+}
+await window.electronAPI.addRecentClient({ ...entry, logoDataUrl, lastOpened: new Date().toISOString() });
+```
+
+---
+
+### Fix B4 + B5 — Use correct prefix in `tryAutoDetect`, guard client mode (`dashboard/app.js`)
+
+**Status: ✅ Implemented**
+
+- `loadLogo`/`loadBg` `onerror` handlers now only call `tryAutoDetect()` when `!isClientMode`.
+- `tryAutoDetect` now fetches `clientPrefix` instead of the hardcoded `'assets/'`, and uses `clientPrefix` when building all guessed filenames.
+
+```javascript
+// loadLogo onerror
+img.onerror = () => {
+    if (!isClientMode) tryAutoDetect();
+};
+
+// tryAutoDetect
+fetch(clientPrefix)   // was hardcoded 'assets/'
+    .then(...)
+    .catch(() => {
+        ['logo', 'client-logo', 'clientlogo'].forEach(base => {
+            exts.forEach(ext => loadLogo(clientPrefix + base + '.' + ext));
+        });
+    });
+```
+
+---
+
+### Fix B6 — Surface config load failure (minor / low-risk)
+
+**Status: ⏳ Recommended (not yet applied)**
+
+Add a `console.warn` so config failures appear in DevTools without breaking the app:
+
+```javascript
+} catch(e) {
+    console.warn('Config load failed — using defaults:', e);
+}
+```
+
+---
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `electron-main.js` | `readFileAsDataUrl` → async + 3-pass sharp resize pipeline |
+| `welcome.html` | `openRecentFolder` → re-reads logo on every open |
+| `dashboard/app.js` | `onerror` guards + `tryAutoDetect` uses `clientPrefix` |
+| `package.json` | Moved `sharp` from `devDependencies` → `dependencies` |
+
+---
+
+## Verification Steps
+
+1. Place a logo **> 256 KB** in a client folder, reference it in `config.json` → open folder → confirm logo appears on home card (auto-resized, not dropped)
+2. Change the logo file on disk → re-open same folder from recents → confirm new logo appears (not cached stale)
+3. Set `logoFile` to a **nonexistent filename** in client mode → open dashboard → confirm no JS errors, graceful fallback to letter/no logo
+4. Delete `config.json` → open dashboard → confirm `console.warn` appears in DevTools, app still loads
+5. Open dashboard **without `?clientKey`** → confirm auto-detect still probes `assets/` directory listing correctly

--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -358,8 +358,10 @@ function detectAssets() {
             setFavicon(src);
         };
         img.onerror = () => {
-            // Fallback to auto-detect when explicit config path fails
-            tryAutoDetect();
+            // Auto-detect is only meaningful in non-client mode; in client mode all
+            // assets must come from config.json via /client-asset/ and the directory
+            // is not listable, so attempting it would silently no-op.
+            if (!isClientMode) tryAutoDetect();
         };
         img.src = src;
     }
@@ -372,8 +374,7 @@ function detectAssets() {
             document.getElementById('bgOverlay').style.backgroundImage = 'url(' + src + ')';
         };
         bgImg.onerror = () => {
-            // Fallback to auto-detect when explicit config path fails
-            tryAutoDetect();
+            if (!isClientMode) tryAutoDetect();
         };
         bgImg.src = src;
     }
@@ -390,7 +391,8 @@ function detectAssets() {
         if (autoDetectAttempted) return;
         autoDetectAttempted = true;
 
-        fetch('assets/')
+        // Use clientPrefix so this works correctly regardless of mode
+        fetch(clientPrefix)
             .then(r => r.ok ? r.text() : '')
             .then(html => {
                 if (!html) return;
@@ -401,25 +403,25 @@ function detectAssets() {
                     const logoName = pickFirstMatch(html, [
                         /href="([^"]*logo[^"]*\.(png|jpg|jpeg|svg|webp))"/i,
                     ]);
-                    if (logoName) loadLogo('assets/' + logoName);
+                    if (logoName) loadLogo(clientPrefix + logoName);
                 }
 
                 if (!bgLoaded) {
                     const bgName = pickFirstMatch(html, [
                         /href="([^"]*\bbackground[^"]*\.(png|jpg|jpeg|svg|webp))"/i,
                     ]);
-                    if (bgName) loadBg('assets/' + bgName);
+                    if (bgName) loadBg(clientPrefix + bgName);
                 }
             })
             .catch(() => {
                 // Last-resort filename guesses when directory listing fails
                 if (!logoLoaded) {
                     ['logo', 'client-logo', 'clientlogo'].forEach(base => {
-                        exts.forEach(ext => loadLogo('assets/' + base + '.' + ext));
+                        exts.forEach(ext => loadLogo(clientPrefix + base + '.' + ext));
                     });
                 }
                 if (!bgLoaded) {
-                    exts.forEach(ext => loadBg('assets/background.' + ext));
+                    exts.forEach(ext => loadBg(clientPrefix + 'background.' + ext));
                 }
             });
     }

--- a/electron-main.js
+++ b/electron-main.js
@@ -242,17 +242,50 @@ function registerIpcHandlers() {
         } catch (_) { return null; }
     });
 
-    // Read an image file from within folderPath; return as base64 data URL (max 256 KB)
-    ipcMain.handle('folder:readFileAsDataUrl', (_, folderPath, filename) => {
+    // Read an image file from within folderPath; return as base64 data URL.
+    // Files already under 250 KB are returned as-is. Larger files are automatically
+    // resized down using sharp (PNG → JPEG progressive fallback) so they always fit
+    // under the 350 K base64 character cap enforced by store:addRecent.
+    ipcMain.handle('folder:readFileAsDataUrl', async (_, folderPath, filename) => {
         if (typeof folderPath !== 'string' || typeof filename !== 'string') return null;
         if (/[\/\\]/.test(filename) || filename.includes('..')) return null;
         try {
             const filePath = path.join(folderPath, filename);
             if (!path.resolve(filePath).startsWith(path.resolve(folderPath))) return null;
             const data = fs.readFileSync(filePath);
-            if (data.length > 256 * 1024) return null; // 256 KB cap for stored data URLs
-            const mime = MIMES[path.extname(filename).toLowerCase()] || 'application/octet-stream';
-            return `data:${mime};base64,${data.toString('base64')}`;
+            const TARGET = 250 * 1024; // 250 KB → ~333 K base64 chars, safely under 350 K cap
+            const ext = path.extname(filename).toLowerCase();
+
+            if (data.length <= TARGET) {
+                const mime = MIMES[ext] || 'application/octet-stream';
+                return `data:${mime};base64,${data.toString('base64')}`;
+            }
+
+            // File exceeds target — resize with sharp rather than silently dropping it
+            const sharp = require('sharp');
+
+            // Pass 1: preserve transparency via PNG, resize to 512×512 max
+            let out = await sharp(data)
+                .resize(512, 512, { fit: 'inside', withoutEnlargement: true })
+                .png({ compressionLevel: 9 })
+                .toBuffer();
+            if (out.length <= TARGET)
+                return `data:image/png;base64,${out.toString('base64')}`;
+
+            // Pass 2: JPEG at 85% quality, 256×256 max (drops transparency)
+            out = await sharp(data)
+                .resize(256, 256, { fit: 'inside', withoutEnlargement: true })
+                .jpeg({ quality: 85 })
+                .toBuffer();
+            if (out.length <= TARGET)
+                return `data:image/jpeg;base64,${out.toString('base64')}`;
+
+            // Pass 3: JPEG at 60% quality, 128×128 (last resort)
+            out = await sharp(data)
+                .resize(128, 128, { fit: 'inside', withoutEnlargement: true })
+                .jpeg({ quality: 60 })
+                .toBuffer();
+            return `data:image/jpeg;base64,${out.toString('base64')}`;
         } catch (_) { return null; }
     });
 

--- a/package.json
+++ b/package.json
@@ -64,6 +64,9 @@
       "sign": null
     }
   },
+  "dependencies": {
+    "sharp": "^0.34.5"
+  },
   "devDependencies": {
     "@electron/packager": "^19.1.0",
     "electron": "^34.0.0",
@@ -73,7 +76,6 @@
     "happy-dom": "^20.8.9",
     "nexe": "^5.0.0-beta.4",
     "rcedit": "^4.0.1",
-    "sharp": "^0.34.5",
     "vitest": "^2.1.9"
   }
 }

--- a/welcome.html
+++ b/welcome.html
@@ -761,9 +761,15 @@ async function openRecentFolder(entry) {
             return;
         }
 
-        // Update lastOpened timestamp
+        // Re-read the logo so the card reflects any changes since the folder was first opened
+        let logoDataUrl = entry.logoDataUrl || '';
+        if (cfg.logoFile) {
+            logoDataUrl = await window.electronAPI.readFileAsDataUrl(entry.path, cfg.logoFile) || logoDataUrl;
+        }
+
         await window.electronAPI.addRecentClient({
             ...entry,
+            logoDataUrl,
             lastOpened: new Date().toISOString(),
         });
 


### PR DESCRIPTION
- electron-main.js: make readFileAsDataUrl async; replace silent 256 KB
  hard cap with a 3-pass sharp resize pipeline (PNG 512px → JPEG 85%
  256px → JPEG 60% 128px) targeting 250 KB so logos always fit under
  the 350 K base64 storage cap instead of being silently dropped
- welcome.html: openRecentFolder now re-reads the logo file on every
  open (same as openNewFolder) so stale or previously-missing logos
  are refreshed automatically
- dashboard/app.js: guard onerror handlers so tryAutoDetect() is never
  called in client mode; fix tryAutoDetect to use clientPrefix instead
  of the hardcoded 'assets/' path so fallback probing works correctly
  in both client and non-client modes
- package.json: move sharp from devDependencies to dependencies so it
  is available in production Electron builds
- Tasks/Bugs/logo-display-analysis.md: full algorithm walkthrough,
  bug table, and fix documentation

https://claude.ai/code/session_0164wRLsP3ZtowBuT7sVPaRT