### PR TITLE
Fix sentinel progress block hidden when no estimatedEnd data

### DIFF
--- a/dashboard/render/stats.js
+++ b/dashboard/render/stats.js
@@ -129,13 +129,23 @@ export function updateSentinelBar() {
     const delta = getTimeDelta();
     const progressBlock = document.getElementById('sentinelProgressBlock');
     const deltaEl       = document.getElementById('sentinelDelta');
+    const timeRow       = document.getElementById('sentinelTimeRow');
 
-    if (progressBlock) progressBlock.classList.toggle('hidden', !delta);
+    // Show progress block whenever timer is active (running/paused), even without estimation data.
+    // The Done bar only needs completion %; the Time bar requires estimatedEnd coverage.
+    const showProgress = ts !== 'stopped' || delta !== null;
+    if (progressBlock) progressBlock.classList.toggle('hidden', !showProgress);
 
+    if (showProgress) {
+        const completionPct = delta ? delta.completionPct : getCompletionPct();
+        _setIfChanged('sentinelDoneFill', null, completionPct + '%');
+        _setIfChanged('sentinelDonePct', completionPct + '%');
+    }
+
+    // Time bar: only visible when estimation data is available
+    if (timeRow) timeRow.classList.toggle('hidden', !delta);
     if (delta) {
-        _setIfChanged('sentinelDoneFill', null, delta.completionPct  + '%');
         _setIfChanged('sentinelTimeFill', null, delta.timeProgressPct + '%');
-        _setIfChanged('sentinelDonePct', delta.completionPct  + '%');
         _setIfChanged('sentinelTimePct', delta.timeProgressPct + '%');
     }
 

--- a/runbookDashboard.html
+++ b/runbookDashboard.html
@@ -604,6 +604,7 @@
     }
     .sentinel-progress-block.hidden { display: none; }
     .sentinel-bar-row { display: flex; align-items: center; gap: 6px; }
+    .sentinel-bar-row.hidden { display: none; }
     .sentinel-bar-label {
         font-size: var(--text-xs); color: var(--text-muted);
         width: 32px; flex-shrink: 0; text-align: right;
@@ -2003,7 +2004,7 @@
             <div class="sentinel-track"><div class="sentinel-fill done" id="sentinelDoneFill"></div></div>
             <span class="sentinel-bar-pct" id="sentinelDonePct">0%</span>
         </div>
-        <div class="sentinel-bar-row">
+        <div class="sentinel-bar-row" id="sentinelTimeRow">
             <span class="sentinel-bar-label">Time</span>
             <div class="sentinel-track"><div class="sentinel-fill time" id="sentinelTimeFill"></div></div>
             <span class="sentinel-bar-pct" id="sentinelTimePct">0%</span>


### PR DESCRIPTION
The Done bar was disappearing entirely whenever tasks lacked estimatedEnd
values because getTimeDelta() returns null in that case, which hid the
whole sentinelProgressBlock. The Done % bar doesn't need estimation data
— only the Time bar does.

Now the progress block shows whenever the timer is active (running/paused),
with the Done bar always rendering task completion % and the Time bar row
hidden unless estimation coverage is sufficient.

https://claude.ai/code/session_01H7ks16Btyv35RB8oCNQqpN