### PR TITLE
Add legal disclaimer, light/dark theme toggle, and dashboard-config.json to welcome page

### DIFF
--- a/dashboard-config.json
+++ b/dashboard-config.json
@@ -1,0 +1,4 @@
+{
+  "theme": "dark",
+  "backgroundImage": "Murex_background6.jpg"
+}

--- a/electron-main.js
+++ b/electron-main.js
@@ -49,6 +49,23 @@ let serverPort       = null;  // set after HTTP server starts
 const RECENT_FILE = path.join(os.homedir(), '.mxrunbook', 'recent-clients.json');
 const RECENT_MAX  = 10;
 
+// ── Dashboard config (global app settings — irrespective of client) ──
+const DASHBOARD_CONFIG_PATH     = path.join(ROOT, 'dashboard-config.json');
+const DASHBOARD_CONFIG_DEFAULTS = { theme: 'dark', backgroundImage: 'Murex_background6.jpg' };
+
+function loadDashboardConfig() {
+    try {
+        return { ...DASHBOARD_CONFIG_DEFAULTS, ...JSON.parse(fs.readFileSync(DASHBOARD_CONFIG_PATH, 'utf8')) };
+    } catch (_) { return { ...DASHBOARD_CONFIG_DEFAULTS }; }
+}
+function saveDashboardConfig(updates) {
+    try {
+        const merged = { ...loadDashboardConfig(), ...updates };
+        fs.writeFileSync(DASHBOARD_CONFIG_PATH, JSON.stringify(merged, null, 2), 'utf8');
+        return merged;
+    } catch (_) { return null; }
+}
+
 function loadRecentClients() {
     try { return JSON.parse(fs.readFileSync(RECENT_FILE, 'utf8')); }
     catch (_) { return []; }
@@ -318,6 +335,16 @@ function registerIpcHandlers() {
     ipcMain.handle('nav:openWelcome', () => {
         if (!win) return;
         win.loadURL(`http://127.0.0.1:${serverPort}/welcome.html`);
+    });
+
+    // Dashboard-level config (theme, background image — irrespective of client)
+    ipcMain.handle('config:getDashboard', () => loadDashboardConfig());
+    ipcMain.handle('config:saveDashboard', (_, updates) => {
+        if (!updates || typeof updates !== 'object' || Array.isArray(updates)) return null;
+        const safe = {};
+        if (typeof updates.theme === 'string')           safe.theme = updates.theme;
+        if (typeof updates.backgroundImage === 'string') safe.backgroundImage = updates.backgroundImage;
+        return saveDashboardConfig(safe);
     });
 }
 

--- a/preload.js
+++ b/preload.js
@@ -60,4 +60,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
     // Navigate the window back to the welcome page.
     openWelcome: () =>
         ipcRenderer.invoke('nav:openWelcome'),
+
+    // ── Dashboard config (theme, background — irrespective of client) ─
+    // Returns the current dashboard-config.json as a plain object.
+    getDashboardConfig: () =>
+        ipcRenderer.invoke('config:getDashboard'),
+
+    // Persists allowed keys (theme, backgroundImage) back to dashboard-config.json.
+    saveDashboardConfig: (updates) =>
+        ipcRenderer.invoke('config:saveDashboard', updates),
 });

--- a/welcome.html
+++ b/welcome.html
@@ -8,6 +8,13 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+<script>
+/* Apply saved theme immediately to avoid flash of wrong theme */
+(function () {
+    var t = localStorage.getItem('welcome_theme') || 'dark';
+    if (t === 'light') document.documentElement.setAttribute('data-theme', 'light');
+})();
+</script>
 <style>
 /* ══════════════════════════════════════════════════════════════
    DESIGN TOKENS — mirrors runbookDashboard.html dark corporate
@@ -527,6 +534,118 @@ body::before {
 }
 .no-electron-inner a:hover { text-decoration: underline; }
 
+/* ══ LIGHT THEME ════════════════════════════════════════════════ */
+[data-theme="light"] {
+    --color-surface:          #f0f2f5;
+    --color-surface-elevated: #ffffff;
+    --color-surface-hover:    #e8eaed;
+    --color-text-primary:     #1a1a2e;
+    --color-text-secondary:   #5a5a7a;
+    --color-text-dim:         #8a8a9a;
+    --color-text-emphasis:    #0a0a1a;
+    --color-border:           #d0d3d9;
+    --color-border-strong:    #b0b3ba;
+    --color-success:          #059669;
+    --color-primary:          #059669;
+
+    --glass-bg:               rgba(255, 255, 255, 0.72);
+    --glass-bg-elevated:      rgba(255, 255, 255, 0.82);
+    --glass-bg-card:          rgba(255, 255, 255, 0.68);
+    --glass-border:           rgba(0, 0, 0, 0.09);
+    --glass-shadow:           0 4px 32px rgba(0, 0, 0, 0.10);
+    --glass-shadow-hover:     0 8px 48px rgba(0, 0, 0, 0.16);
+}
+
+[data-theme="light"] body {
+    background: var(--color-surface);
+}
+
+/* Tone down the dark background photo in light mode */
+html[data-theme="light"] #bgOverlay {
+    opacity: 0.30;
+    filter: brightness(1.15) saturate(0.75);
+}
+
+/* Tone down the dark ambient gradients in light mode */
+html[data-theme="light"] body::before {
+    opacity: 0.12;
+}
+
+[data-theme="light"] .open-card:hover {
+    background: rgba(255, 255, 255, 0.92);
+    border-left-color: #059669;
+}
+
+[data-theme="light"] .recent-card:hover {
+    background: rgba(255, 255, 255, 0.92);
+}
+
+[data-theme="light"] .version-badge {
+    background: rgba(0, 0, 0, 0.05);
+    border-color: var(--color-border);
+}
+
+/* ══ THEME TOGGLE BUTTON ════════════════════════════════════════ */
+.theme-toggle-btn {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    z-index: 200;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    border: 1px solid var(--glass-border);
+    background: var(--glass-bg-elevated);
+    backdrop-filter: blur(var(--glass-blur));
+    -webkit-backdrop-filter: blur(var(--glass-blur));
+    box-shadow: var(--glass-shadow);
+    color: var(--color-text-primary);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    transition: transform 0.18s ease, box-shadow 0.18s ease;
+    flex-shrink: 0;
+}
+.theme-toggle-btn:hover {
+    transform: scale(1.10);
+    box-shadow: var(--glass-shadow-hover);
+}
+.theme-toggle-btn svg {
+    width: 20px;
+    height: 20px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    flex-shrink: 0;
+}
+
+/* Sun icon shown in dark mode (click → go light); Moon shown in light mode (click → go dark) */
+.icon-moon { display: none; }
+[data-theme="light"] .icon-sun  { display: none; }
+[data-theme="light"] .icon-moon { display: block; }
+
+/* ══ LEGAL DISCLAIMER ═══════════════════════════════════════════ */
+.legal-disclaimer {
+    width: 100%;
+    max-width: 720px;
+    margin-top: 40px;
+    padding: 20px 24px;
+    text-align: center;
+    font-size: 0.70rem;
+    line-height: 1.80;
+    color: #9ca3af;
+    border-top: 1px solid var(--glass-border);
+    letter-spacing: 0.01em;
+    animation: fadeInUp 0.7s 0.35s ease both;
+}
+[data-theme="light"] .legal-disclaimer {
+    color: #6b7280;
+}
+
 /* ══ ANIMATIONS ═════════════════════════════════════════════════ */
 @keyframes fadeInUp {
     from { opacity: 0; transform: translateY(18px); }
@@ -541,6 +660,26 @@ body::before {
 
 <!-- ── Background ──────────────────────────────────────────────── -->
 <div id="bgOverlay"></div>
+
+<!-- ── Theme toggle (fixed, top-right) ─────────────────────────── -->
+<button class="theme-toggle-btn" id="themeToggleBtn" aria-label="Toggle light/dark theme" title="Toggle light/dark theme">
+    <!-- Sun icon: visible in dark mode, click to switch to light -->
+    <svg class="icon-sun" viewBox="0 0 24 24" aria-hidden="true">
+        <circle cx="12" cy="12" r="5"/>
+        <line x1="12" y1="1"  x2="12" y2="3"/>
+        <line x1="12" y1="21" x2="12" y2="23"/>
+        <line x1="4.22" y1="4.22"   x2="5.64"  y2="5.64"/>
+        <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+        <line x1="1"  y1="12" x2="3"  y2="12"/>
+        <line x1="21" y1="12" x2="23" y2="12"/>
+        <line x1="4.22" y1="19.78"  x2="5.64"  y2="18.36"/>
+        <line x1="18.36" y1="5.64"  x2="19.78" y2="4.22"/>
+    </svg>
+    <!-- Moon icon: visible in light mode, click to switch to dark -->
+    <svg class="icon-moon" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+    </svg>
+</button>
 
 <!-- ── Main layout ─────────────────────────────────────────────── -->
 <div class="welcome-root">
@@ -594,6 +733,13 @@ body::before {
         </div>
     </section>
 
+    <!-- Legal disclaimer -->
+    <footer class="legal-disclaimer">
+        Legal Notice: The MX runbook Monitor software and documentation is valuable confidential and proprietary information.<br>
+        Any access or use other than as expressly authorized by Murex could expose you and your company to liability and/or prosecution.<br>
+        &copy; Copyright Murex SAS 1987, 2026. All rights reserved.
+    </footer>
+
 </div><!-- /welcome-root -->
 
 <!-- Toast notification -->
@@ -607,6 +753,33 @@ body::before {
 <script>
 (function () {
 'use strict';
+
+// ── Dashboard config & theme ─────────────────────────────────────
+let _dashCfg = { theme: 'dark', backgroundImage: 'Murex_background6.jpg' };
+
+function applyDashboardConfig(cfg) {
+    _dashCfg = { ..._dashCfg, ...cfg };
+    const theme = _dashCfg.theme === 'light' ? 'light' : 'dark';
+    if (theme === 'light') {
+        document.documentElement.setAttribute('data-theme', 'light');
+    } else {
+        document.documentElement.removeAttribute('data-theme');
+    }
+    // Apply configurable background image
+    const bg = _dashCfg.backgroundImage || 'Murex_background6.jpg';
+    document.getElementById('bgOverlay').style.backgroundImage = `url('assets/${bg}')`;
+    // Keep localStorage in sync for instant-apply on next load
+    localStorage.setItem('welcome_theme', theme);
+}
+
+async function toggleTheme() {
+    const current = document.documentElement.getAttribute('data-theme') || 'dark';
+    const next = current === 'light' ? 'dark' : 'light';
+    applyDashboardConfig({ theme: next });
+    if (window.electronAPI && window.electronAPI.saveDashboardConfig) {
+        await window.electronAPI.saveDashboardConfig({ theme: next });
+    }
+}
 
 // ── Toast helper ────────────────────────────────────────────────
 let _toastTimer = null;
@@ -783,8 +956,15 @@ async function openRecentFolder(entry) {
 
 // ── Boot ─────────────────────────────────────────────────────────
 async function init() {
+    // Wire theme toggle (works regardless of Electron)
+    document.getElementById('themeToggleBtn').addEventListener('click', toggleTheme);
+
     // Guard: this page requires Electron
     if (!window.electronAPI || !window.electronAPI.isElectron) {
+        // Apply theme from localStorage fallback (already set by head script)
+        const savedTheme = localStorage.getItem('welcome_theme') || 'dark';
+        applyDashboardConfig({ theme: savedTheme });
+
         const msg = document.createElement('div');
         msg.className = 'no-electron-msg';
         msg.innerHTML = `
@@ -796,6 +976,14 @@ async function init() {
             </div>`;
         document.body.appendChild(msg);
         return;
+    }
+
+    // Load dashboard-config.json and apply theme + background
+    try {
+        const cfg = await window.electronAPI.getDashboardConfig();
+        if (cfg) applyDashboardConfig(cfg);
+    } catch (_) {
+        // Fall back to whatever the head script already applied
     }
 
     // Wire open button


### PR DESCRIPTION
- welcome.html: add fixed sun/moon theme toggle button (top-right) with full light-mode
  CSS variable overrides, toned-down background/ambients for light mode, and a
  legal-notice footer (grey #9ca3af dark / #6b7280 light) visible in both themes
- welcome.html: apply theme instantly in <head> from localStorage to avoid FOUC;
  on init, load dashboard-config.json via Electron IPC and sync back on toggle
- dashboard-config.json: new app-level config file (irrespective of client) with
  theme (dark/light) and backgroundImage as the first two settings
- electron-main.js: add loadDashboardConfig / saveDashboardConfig helpers and two
  IPC handlers (config:getDashboard, config:saveDashboard) with key whitelisting
- preload.js: expose getDashboardConfig and saveDashboardConfig on window.electronAPI

https://claude.ai/code/session_01BR9cxQqbvcrg1TLEsa3pfs