### PR TITLE
Fix: accept bare HH:MM:SS times in schema; add runbook_date anchor in UI

### DIFF
--- a/adapter/schema.py
+++ b/adapter/schema.py
@@ -2,11 +2,19 @@
 import json
 import re
 
-# ISO datetime pattern accepted by the dashboard JS (new Date(val))
+# Accepted datetime strings:
+#   Full ISO date (with optional time):  YYYY-MM-DD[THH:MM[:SS]]
+#   Bare time (from time-only columns):  HH:MM[:SS]
+# Bare times are valid because Excel/CSV files often store date and time in
+# separate columns; the parser combines them when runbook_date is set in the
+# mapping.  The quality checker emits a warning when no date is present so
+# users know to set runbook_date if they need full timestamps.
 _ISO_RE = re.compile(
-    r"^\d{4}-\d{2}-\d{2}"          # date part YYYY-MM-DD
-    r"([T ]\d{2}:\d{2}(:\d{2})?)?"  # optional time T/space HH:MM[:SS]
-    r"$"
+    r"^("
+    r"\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}(:\d{2})?)?"  # full ISO: YYYY-MM-DD[THH:MM[:SS]]
+    r"|"
+    r"\d{2}:\d{2}(:\d{2})?"                             # bare time: HH:MM[:SS]
+    r")$"
 )
 
 RUNBOOK_SCHEMA = {

--- a/gui/pages/step2_mapping.py
+++ b/gui/pages/step2_mapping.py
@@ -74,6 +74,16 @@ def update_status_mapping(source: str, canonical: str) -> None:
     state.mapping = m
 
 
+def update_runbook_date(value: str | None) -> None:
+    """Set (or clear) the anchor date used to complete bare HH:MM[:SS] time cells."""
+    m = state.mapping
+    if value and value.strip():
+        m["runbook_date"] = value.strip()
+    else:
+        m.pop("runbook_date", None)
+    state.mapping = m
+
+
 def is_ready() -> bool:
     """True when both required fields (task, status) have a column assigned."""
     cols = state.mapping.get("columns", {})
@@ -187,6 +197,30 @@ def render(stepper) -> None:  # noqa: ARG001
                 ui.label("Optional — groups tasks into collapsible sections").style(
                     "color: var(--color-text-dim); font-size: 0.8rem;"
                 )
+
+            # ── Runbook date (anchor for time-only cells) ─
+            with ui.row().classes("items-center").style("gap: 12px; margin-top: 6px;"):
+                ui.label("Runbook date").style(
+                    "color: var(--color-text-primary); font-size: 0.9rem; min-width: 160px;"
+                )
+                date_val = state.mapping.get("runbook_date", "")
+
+                def _on_date(e):
+                    update_runbook_date(e.value)
+
+                ui.input(
+                    value=date_val or "",
+                    placeholder="YYYY-MM-DD  (e.g. 2026-04-15)",
+                    on_change=_on_date,
+                ).props("dense clearable").style("min-width: 200px;")
+
+                with ui.row().classes("items-center").style("gap: 4px;"):
+                    ui.icon("info_outline").style(
+                        "color: var(--color-text-dim); font-size: 1rem;"
+                    )
+                    ui.label(
+                        "Optional — fills the date part when time cells contain only HH:MM:SS"
+                    ).style("color: var(--color-text-dim); font-size: 0.8rem;")
 
             # ── Required-field warning banner ───────────
             missing = [

--- a/gui/tests/test_bare_time_fix.py
+++ b/gui/tests/test_bare_time_fix.py
@@ -1,0 +1,233 @@
+"""
+Tests for bare-time tolerance (schema.py + step2_mapping.update_runbook_date).
+
+Context: Excel/CSV files often store date and time in separate columns so
+time fields contain only HH:MM:SS strings.  These should be accepted by the
+schema validator (not treated as errors) and routed through the quality
+checker as warnings.  When the user sets ``runbook_date`` in the mapping the
+parser combines it with bare times to produce full ISO datetimes.
+
+Run with:  pytest gui/tests/test_bare_time_fix.py -v
+"""
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+# ── schema.validate — bare time strings ───────────────────
+
+class TestSchemaValidateBareTime:
+    def _validate(self, data):
+        from adapter.schema import validate
+        return validate(data)
+
+    def test_bare_time_hh_mm_ss_is_valid(self):
+        errors = self._validate({
+            "Phase 1": [{"task": "Deploy", "status": "Done", "startTime": "09:00:00"}]
+        })
+        assert errors == [], f"Expected no errors, got: {errors}"
+
+    def test_bare_time_hh_mm_is_valid(self):
+        errors = self._validate({
+            "Phase 1": [{"task": "Deploy", "status": "Done", "startTime": "09:35"}]
+        })
+        assert errors == []
+
+    def test_bare_time_end_time_is_valid(self):
+        errors = self._validate({
+            "Phase 1": [{"task": "Deploy", "status": "Done",
+                         "startTime": "09:00:00", "endTime": "09:45:00"}]
+        })
+        assert errors == []
+
+    def test_bare_time_estimated_end_is_valid(self):
+        errors = self._validate({
+            "Phase 1": [{
+                "task": "Deploy", "status": "Done",
+                "startTime": "09:00:00", "endTime": "09:30:00",
+                "estimatedEnd": "09:45:00",
+            }]
+        })
+        assert errors == []
+
+    def test_full_iso_datetime_still_valid(self):
+        errors = self._validate({
+            "Phase 1": [{"task": "T", "status": "Done",
+                         "startTime": "2026-04-15T09:00:00"}]
+        })
+        assert errors == []
+
+    def test_full_iso_date_only_still_valid(self):
+        errors = self._validate({
+            "Phase 1": [{"task": "T", "status": "Done", "startTime": "2026-04-15"}]
+        })
+        assert errors == []
+
+    def test_garbage_string_still_invalid(self):
+        errors = self._validate({
+            "Phase 1": [{"task": "T", "status": "Done", "startTime": "not-a-time"}]
+        })
+        assert any("startTime" in e for e in errors)
+
+    def test_real_world_runbook_bare_times(self):
+        """Reproduces the exact error strings seen in the user's Excel runbook."""
+        errors = self._validate({
+            "Murex": [{"task": "Start Murex", "status": "Not Started",
+                       "startTime": "09:00:00"}],
+            "Deploy the migration interface": [
+                {"task": "Deploy interface", "status": "Not Started",
+                 "startTime": "09:35:00", "endTime": "09:45:00",
+                 "estimatedEnd": "09:45:00"}
+            ],
+            "Purge export interface consumer": [
+                {"task": "Purge consumer", "status": "Not Started",
+                 "startTime": "09:45:00"}
+            ],
+        })
+        assert errors == [], f"Expected no errors, got: {errors}"
+
+
+# ── quality.check — bare times become warnings, not errors ─
+
+class TestQualityBareTimeWarnings:
+    def _quality(self, data):
+        from adapter.quality import check
+        return check(data)
+
+    def test_bare_time_produces_warning_not_error(self):
+        report = self._quality({
+            "Phase 1": [{"task": "Deploy", "status": "Done", "startTime": "09:00:00"}]
+        })
+        # Should be a warning (informational), not a blocking error
+        warnings_text = " ".join(report.get("warnings", []))
+        assert "09:00:00" in warnings_text
+        assert report["errors"] == []
+
+    def test_full_iso_produces_no_bare_time_warning(self):
+        report = self._quality({
+            "Phase 1": [{"task": "Deploy", "status": "Done",
+                         "startTime": "2026-04-15T09:00:00",
+                         "endTime":   "2026-04-15T09:30:00"}]
+        })
+        assert not any("no date component" in w for w in report.get("warnings", []))
+
+
+# ── update_runbook_date() ─────────────────────────────────
+
+class TestUpdateRunbookDate:
+    def setup_method(self):
+        from gui.state import state
+        state.reset()
+        state.mapping = {"columns": {}, "category_column": None, "status_mapping": {}}
+
+    def test_sets_runbook_date(self):
+        from gui.state import state
+        from gui.pages.step2_mapping import update_runbook_date
+        update_runbook_date("2026-04-15")
+        assert state.mapping["runbook_date"] == "2026-04-15"
+
+    def test_clears_runbook_date_on_empty_string(self):
+        from gui.state import state
+        from gui.pages.step2_mapping import update_runbook_date
+        update_runbook_date("2026-04-15")
+        update_runbook_date("")
+        assert "runbook_date" not in state.mapping
+
+    def test_clears_runbook_date_on_none(self):
+        from gui.state import state
+        from gui.pages.step2_mapping import update_runbook_date
+        update_runbook_date("2026-04-15")
+        update_runbook_date(None)
+        assert "runbook_date" not in state.mapping
+
+    def test_strips_whitespace(self):
+        from gui.state import state
+        from gui.pages.step2_mapping import update_runbook_date
+        update_runbook_date("  2026-04-15  ")
+        assert state.mapping["runbook_date"] == "2026-04-15"
+
+    def test_reassigns_mapping_reference(self):
+        from gui.state import state
+        from gui.pages.step2_mapping import update_runbook_date
+        update_runbook_date("2026-04-15")
+        assert state.mapping.get("runbook_date") == "2026-04-15"
+
+
+# ── Integration: bare times + runbook_date → full ISO ─────
+
+class TestBareTimeWithAnchorDate:
+    def test_excel_parser_resolves_bare_time_with_anchor(self):
+        """With runbook_date set, bare HH:MM:SS → full ISO datetime string."""
+        import io
+        import tempfile
+        import os
+        openpyxl = __import__("openpyxl")
+
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.append(["Task", "Status", "Start", "End"])
+        # Time-only cells (stored as Python time objects by openpyxl when reading,
+        # but we simulate the string path here)
+        ws.append(["Deploy", "Done", "09:00:00", "09:30:00"])
+
+        buf = io.BytesIO()
+        wb.save(buf)
+
+        with tempfile.NamedTemporaryFile(suffix=".xlsx", delete=False) as f:
+            f.write(buf.getvalue())
+            tmp = f.name
+
+        try:
+            from adapter.parsers.excel_parser import parse
+            mapping = {
+                "columns": {
+                    "task": "Task", "status": "Status",
+                    "startTime": "Start", "endTime": "End",
+                },
+                "runbook_date": "2026-04-15",
+            }
+            result = parse(tmp, mapping)
+            tasks = result.get("Tasks", [])
+            assert len(tasks) == 1
+            # With anchor date, startTime should include the date component
+            start = tasks[0].get("startTime", "")
+            assert start.startswith("2026-04-15"), (
+                f"Expected full ISO datetime, got: {start!r}"
+            )
+        finally:
+            os.remove(tmp)
+
+    def test_excel_parser_bare_time_no_anchor_passes_through(self):
+        """Without runbook_date, bare times pass through as HH:MM:SS strings."""
+        import io
+        import tempfile
+        import os
+        openpyxl = __import__("openpyxl")
+
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.append(["Task", "Status", "Start"])
+        ws.append(["Deploy", "Done", "09:00:00"])
+
+        buf = io.BytesIO()
+        wb.save(buf)
+
+        with tempfile.NamedTemporaryFile(suffix=".xlsx", delete=False) as f:
+            f.write(buf.getvalue())
+            tmp = f.name
+
+        try:
+            from adapter.parsers.excel_parser import parse
+            mapping = {
+                "columns": {"task": "Task", "status": "Status", "startTime": "Start"},
+            }
+            result = parse(tmp, mapping)
+            tasks = result.get("Tasks", [])
+            assert len(tasks) == 1
+            start = tasks[0].get("startTime", "")
+            # Bare time passes through — schema now accepts it, quality will warn
+            assert start in ("09:00:00", "09:00"), f"Unexpected: {start!r}"
+        finally:
+            os.remove(tmp)


### PR DESCRIPTION
Problem: Excel runbooks with time-only columns (e.g. '09:00:00') were
rejected by the schema validator, blocking export entirely.

Fixes:
- adapter/schema.py: _ISO_RE now also matches bare HH:MM[:SS] strings.
  Full ISO dates and full ISO datetimes are unchanged. Garbage strings
  (e.g. 'not-a-time') are still rejected. The quality checker already
  emits a warning for bare times ('no date component') which guides users
  to set runbook_date if they want full timestamps — that behaviour is
  preserved.

- gui/pages/step2_mapping.py: add update_runbook_date() pure function and
  a 'Runbook date' input row in the mapping UI. When the user fills in
  YYYY-MM-DD the Excel/CSV parser combines it with bare time cells to
  produce full ISO datetimes (existing parser feature, now surfaced in GUI).

Tests: 17 new tests in test_bare_time_fix.py covering:
  - schema.validate accepts HH:MM, HH:MM:SS, full ISO (all pass)
  - garbage strings still rejected
  - real-world runbook case (exact strings from user's error report)
  - quality.check routes bare times to warnings (not errors)
  - update_runbook_date set/clear/strip behaviour
  - parser integration: bare time + anchor → full ISO datetime

113/113 total tests passing.

https://claude.ai/code/session_01CEySjg9EP366bZP3C23ucX